### PR TITLE
Differentiate between touch and mouse

### DIFF
--- a/projects/monocle-ngx/src/lib/directives/change.directive.spec.ts
+++ b/projects/monocle-ngx/src/lib/directives/change.directive.spec.ts
@@ -38,7 +38,7 @@ describe('ChangeDirective', () => {
     expect(mockEventDispatchService.trackChange).toHaveBeenCalledWith(expectedEvent);
   }));
 
-  it('dispatches a change event using keyboard input', fakeAsync(() => {
+  it('dispatches a change event when using a keyboard', fakeAsync(() => {
     const expectedEvent = {
       id: 'checkboxId',
       interactionType: 'change',
@@ -49,6 +49,24 @@ describe('ChangeDirective', () => {
     };
     const input = fixture.nativeElement.querySelector('#checkboxId');
     input.dispatchEvent(new Event('keydown'));
+    input.click();
+    tick();
+    expect(mockEventDispatchService.trackChange).toHaveBeenCalledTimes(1);
+    expect(mockEventDispatchService.trackChange).toHaveBeenCalledWith(expectedEvent);
+  }));
+
+  it('dispatches a change event when using touch', fakeAsync(() => {
+    const expectedEvent = {
+      id: 'checkboxId',
+      interactionType: 'change',
+      interactionDetail: 'touch',
+      label: 'My default answer',
+      value: 'checked',
+      displayValue: 'My default answer',
+    };
+    const input = fixture.nativeElement.querySelector('#checkboxId');
+    input.dispatchEvent(new Event('touchstart'));
+    input.dispatchEvent(new Event('mousedown'));
     input.click();
     tick();
     expect(mockEventDispatchService.trackChange).toHaveBeenCalledTimes(1);

--- a/projects/monocle-ngx/src/lib/directives/change.directive.ts
+++ b/projects/monocle-ngx/src/lib/directives/change.directive.ts
@@ -35,7 +35,14 @@ export class ChangeDirective implements OnInit {
 
   @HostListener('mousedown', ['$event'])
   onMousedown(): void {
-    this.interactionDetail = InteractionDetail.mouse;
+    if (this.interactionDetail !== InteractionDetail.touch) {
+      this.interactionDetail = InteractionDetail.mouse;
+    }
+  }
+
+  @HostListener('touchstart', ['$event'])
+  onTouchstart(): void {
+    this.interactionDetail = InteractionDetail.touch;
   }
 
   constructor(private elementRef: ElementRef<HTMLSelectElement>, private eventDispatchService: EventDispatchService) {}

--- a/projects/monocle-ngx/src/lib/directives/click.directive.spec.ts
+++ b/projects/monocle-ngx/src/lib/directives/click.directive.spec.ts
@@ -31,6 +31,38 @@ describe('ClickDirective', () => {
       label: 'Simple button',
     };
     const button = fixture.nativeElement.querySelector('#testId');
+    button.dispatchEvent(new Event('keydown'));
+    button.click();
+    tick();
+    expect(mockEventDispatchService.trackClick).toHaveBeenCalledTimes(1);
+    expect(mockEventDispatchService.trackClick).toHaveBeenCalledWith(expectedEvent);
+  }));
+
+  it('dispatches a click event when using a mouse', fakeAsync(() => {
+    const expectedEvent = {
+      id: 'testId',
+      interactionType: 'click',
+      interactionDetail: 'mouse',
+      label: 'Simple button',
+    };
+    const button = fixture.nativeElement.querySelector('#testId');
+    button.dispatchEvent(new Event('mousedown'));
+    button.click();
+    tick();
+    expect(mockEventDispatchService.trackClick).toHaveBeenCalledTimes(1);
+    expect(mockEventDispatchService.trackClick).toHaveBeenCalledWith(expectedEvent);
+  }));
+
+  it('dispatches a click event when using touch', fakeAsync(() => {
+    const expectedEvent = {
+      id: 'testId',
+      interactionType: 'click',
+      interactionDetail: 'touch',
+      label: 'Simple button',
+    };
+    const button = fixture.nativeElement.querySelector('#testId');
+    button.dispatchEvent(new Event('touchstart'));
+    button.dispatchEvent(new Event('mousedown'));
     button.click();
     tick();
     expect(mockEventDispatchService.trackClick).toHaveBeenCalledTimes(1);
@@ -46,13 +78,14 @@ describe('ClickDirective', () => {
       linkUrl: '/somewhere',
     };
     const link = fixture.nativeElement.querySelector('#linkWithRouterLink');
+    link.dispatchEvent(new Event('keydown'));
     link.click();
     tick();
     expect(mockEventDispatchService.trackClick).toHaveBeenCalledTimes(1);
     expect(mockEventDispatchService.trackClick).toHaveBeenCalledWith(expectedEvent);
   }));
 
-  it('prioritizes Event properties over host element attributes when both are provided', fakeAsync(() => {
+  it('prioritizes bound properties over host element attributes when both are provided', fakeAsync(() => {
     const expectedEvent = {
       id: 'eventId',
       interactionType: 'click',
@@ -60,15 +93,17 @@ describe('ClickDirective', () => {
       label: 'Event label',
     };
     const button = fixture.nativeElement.querySelector('#useEventId');
+    button.dispatchEvent(new Event('keydown'));
     button.click();
     tick();
     expect(mockEventDispatchService.trackClick).toHaveBeenCalledTimes(1);
     expect(mockEventDispatchService.trackClick).toHaveBeenCalledWith(expectedEvent);
   }));
 
-  it('does not dispatch a click event when no identifier is provided', fakeAsync(() => {
+  it('does not dispatch a click event when an identifier is missing', fakeAsync(() => {
     console.warn = jasmine.createSpy('warn');
     const button = fixture.nativeElement.querySelector('.someClass');
+    button.dispatchEvent(new Event('keydown'));
     button.click();
     tick();
     expect(mockEventDispatchService.trackClick).toHaveBeenCalledTimes(0);

--- a/projects/monocle-ngx/src/lib/directives/click.directive.ts
+++ b/projects/monocle-ngx/src/lib/directives/click.directive.ts
@@ -10,18 +10,36 @@ import { EventDispatchService } from '../services/event-dispatch.service';
 })
 export class ClickDirective {
   @Input('mnclClick') analyticEventInput: AnalyticEvent | '' = '';
+  interactionDetail: InteractionDetail | undefined = undefined;
 
   @HostListener('click', ['$event'])
-  onClick(mouseEvent: MouseEvent): void {
+  onClick(): void {
     const analyticEvent = this.getAnalyticEvent();
     this.determineId(analyticEvent);
     if (this.shouldDispatch(analyticEvent)) {
       analyticEvent.interactionType = InteractionType.click;
-      this.determineInteractionDetail(analyticEvent, mouseEvent);
+      this.determineInteractionDetail(analyticEvent);
       this.determineLabel(analyticEvent);
       this.determineHostUrl(analyticEvent);
       this.handleEvent(analyticEvent);
     }
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeydown(): void {
+    this.interactionDetail = InteractionDetail.keyboard;
+  }
+
+  @HostListener('mousedown', ['$event'])
+  onMousedown(): void {
+    if (this.interactionDetail !== InteractionDetail.touch) {
+      this.interactionDetail = InteractionDetail.mouse;
+    }
+  }
+
+  @HostListener('touchstart', ['$event'])
+  onTouchstart(): void {
+    this.interactionDetail = InteractionDetail.touch;
   }
 
   constructor(
@@ -40,8 +58,8 @@ export class ClickDirective {
     }
   }
 
-  private determineInteractionDetail(analyticEvent: AnalyticEvent, mouseEvent: MouseEvent): void {
-    analyticEvent.interactionDetail = mouseEvent.detail === 0 ? InteractionDetail.keyboard : InteractionDetail.mouse;
+  private determineInteractionDetail(analyticEvent: AnalyticEvent): void {
+    analyticEvent.interactionDetail = this.interactionDetail;
   }
 
   private determineLabel(analyticEvent: AnalyticEvent): void {

--- a/projects/monocle-ngx/src/lib/models/interaction-detail.enum.ts
+++ b/projects/monocle-ngx/src/lib/models/interaction-detail.enum.ts
@@ -1,4 +1,5 @@
 export enum InteractionDetail {
   mouse = 'mouse',
   keyboard = 'keyboard',
+  touch = 'touch',
 }


### PR DESCRIPTION
<!--
  Thank you for sending a pull request!
  Please take a look at our contribution guide: https://github.com/Progressive/monocle-ngx/blob/main/CONTRIBUTING.md
  One of the project maintainers will review your PR.
-->

# :eyes: Pull Request

**What type of PR is this**

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [x] Refactor
- [ ] Pipeline
- [ ] Documentation

**Which issue(s) does this PR address?**
Fixes #51 
<!--List issue(s) below. Use "fixes #X" or "closes #X" and the issue will close automatically when the PR is merged.-->

**What does this PR do? Why do we need it?**
- Aligns design for detecting interaction details between mnclChange and mcnlClick
- Adds feature to differentiate between mouse and touch inputs

**Does this PR include breaking changes? Does it contain changes that are not backwards compatible?**

- [ ] Yes
- [x] No

<!-- List any changes made in this PR that aren't backwards-compatible. -->

**Additional information**

<!-- Include anything that would help your reviewer (e.g. screenshots). -->
