### PR TITLE
Export change directive and queue intercepts

### DIFF
--- a/projects/oculr-ngx/src/lib/interceptors/analytics.interceptor.ts
+++ b/projects/oculr-ngx/src/lib/interceptors/analytics.interceptor.ts
@@ -18,6 +18,7 @@ import {
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { switchMap, take, tap } from 'rxjs/operators';
+import { ApiContext } from '../models/api-context.interface';
 import { ApiEventContext } from '../models/api-event-context.interface';
 import { AppConfiguration } from '../models/app-configuration.interface';
 import { ConfigurationService } from '../services/configuration.service';
@@ -28,8 +29,17 @@ export const API_EVENT_CONTEXT = new HttpContextToken(() => {
   return { start: {}, success: {}, failure: {} };
 });
 
+interface QueuedIntercept {
+  context: ApiContext;
+  request: HttpRequest<unknown>;
+  response?: HttpResponse<unknown> | HttpErrorResponse;
+  duration?: number;
+}
+
 @Injectable()
 export class AnalyticsInterceptor implements HttpInterceptor {
+  private queuedIntercepts: QueuedIntercept[] = [];
+
   constructor(
     private eventDispatchService: EventDispatchService,
     private timeService: TimeService,
@@ -43,7 +53,9 @@ export class AnalyticsInterceptor implements HttpInterceptor {
         if (config.destinations) {
           const excludedUrls = config.destinations?.map((dest) => dest.endpoint || '') || [];
 
-          if (request.url && !excludedUrls?.includes(request.url)) {
+          this.dequeueIntercepts(excludedUrls);
+
+          if (this.isUrlIncluded(request, excludedUrls)) {
             const requestStartTime = this.timeService.now();
             const { start, success, failure } = request.context.get<ApiEventContext>(API_EVENT_CONTEXT);
 
@@ -72,8 +84,69 @@ export class AnalyticsInterceptor implements HttpInterceptor {
           }
           return next.handle(request);
         }
-        return next.handle(request);
+        return this.queueIntercept(request, next);
       })
     );
+  }
+
+  private queueIntercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    const requestStartTime = this.timeService.now();
+    const { start, success, failure } = request.context.get<ApiEventContext>(API_EVENT_CONTEXT);
+
+    this.queuedIntercepts.push({ context: start, request });
+
+    return next.handle(request).pipe(
+      tap(
+        (event: HttpEvent<unknown>) => {
+          if (event instanceof HttpResponse) {
+            const requestEndTime = this.timeService.now();
+            const duration = Math.round(requestEndTime - requestStartTime);
+
+            this.queuedIntercepts.push({
+              context: success,
+              request,
+              response: event,
+              duration,
+            });
+          }
+        },
+        (error: unknown) => {
+          if (error instanceof HttpErrorResponse) {
+            const requestEndTime = this.timeService.now();
+            const duration = Math.round(requestEndTime - requestStartTime);
+
+            this.queuedIntercepts.push({
+              context: failure,
+              request,
+              response: error,
+              duration,
+            });
+          }
+        }
+      )
+    );
+  }
+
+  private dequeueIntercepts(excludedUrls: string[]): void {
+    while (this.queuedIntercepts.length > 0) {
+      const intercept = this.queuedIntercepts.shift();
+
+      if (intercept && this.isUrlIncluded(intercept?.request, excludedUrls)) {
+        if (intercept.response) {
+          this.eventDispatchService.trackApiComplete(
+            intercept.context,
+            intercept.response,
+            intercept.request,
+            intercept.duration || 0
+          );
+        } else {
+          this.eventDispatchService.trackApiStart(intercept.context, intercept.request);
+        }
+      }
+    }
+  }
+
+  private isUrlIncluded(request: HttpRequest<unknown>, excludedUrls: string[]): boolean {
+    return !!request.url && !excludedUrls?.includes(request.url);
   }
 }

--- a/projects/oculr-ngx/src/lib/oculr-ngx.module.ts
+++ b/projects/oculr-ngx/src/lib/oculr-ngx.module.ts
@@ -11,6 +11,7 @@ import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
 import { ConsoleService } from './destinations/console/console.service';
 import { SplunkService } from './destinations/splunk/splunk.service';
+import { ChangeDirective } from './directives/change.directive';
 import { ClickDirective } from './directives/click.directive';
 import { DisplayDirective } from './directives/display.directive';
 import { AnalyticsInterceptor } from './interceptors/analytics.interceptor';
@@ -24,8 +25,8 @@ import { WindowService } from './services/window.service';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [DisplayDirective, ClickDirective],
-  exports: [DisplayDirective, ClickDirective],
+  declarations: [DisplayDirective, ClickDirective, ChangeDirective],
+  exports: [DisplayDirective, ClickDirective, ChangeDirective],
   providers: [],
 })
 export class OculrAngularModule {

--- a/projects/oculr-ngx/src/public-api.ts
+++ b/projects/oculr-ngx/src/public-api.ts
@@ -12,6 +12,7 @@ export { GoogleTagManagerService } from './lib/destinations/google-tag-manager/g
 
 export { DisplayDirective } from './lib/directives/display.directive';
 export { ClickDirective } from './lib/directives/click.directive';
+export { ChangeDirective } from './lib/directives/change.directive';
 
 export { API_EVENT_CONTEXT } from './lib/interceptors/analytics.interceptor';
 


### PR DESCRIPTION
<!--
  Thank you for sending a pull request!
  Please take a look at our contribution guide: https://github.com/Progressive/oculr-ngx/blob/main/CONTRIBUTING.md
  One of the project maintainers will review your PR.
-->

# :eyes: Pull Request

**What type of PR is this**

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [x] Refactor
- [ ] Pipeline
- [ ] Documentation

**Which issue(s) does this PR address?**

<!--List issue(s) below. Use "fixes #X" or "closes #X" and the issue will close automatically when the PR is merged.-->

N/A

**What does this PR do? Why do we need it?**

This PR completes the refactor of the `AnalyticsInterceptor` so that it can save off requests that occur before library configuration has been completed.  Once configuration is completed, it dispatches these events before handling the current request.

The `ChangeDirective` is also added to the `exports` array in order to expose it to clients.


**Does this PR include breaking changes? Does it contain changes that are not backwards compatible?**

- [ ] Yes
- [x] No

<!-- List any changes made in this PR that aren't backwards-compatible. -->

**Additional information**

<!-- Include anything that would help your reviewer (e.g. screenshots). -->
