### PR TITLE
Dequeue intercepts once config is set

### DIFF
--- a/projects/oculr-ngx/src/lib/services/location.service.spec.ts
+++ b/projects/oculr-ngx/src/lib/services/location.service.spec.ts
@@ -53,7 +53,6 @@ describe('LocationService', () => {
         virtualPageName: '/innersource/catalog',
       };
       const result = locationService.getLocation();
-      console.log(result);
       expect(result).toEqual(expected);
     });
   });


### PR DESCRIPTION
<!--
  Thank you for sending a pull request!
  Please take a look at our contribution guide: https://github.com/Progressive/oculr-ngx/blob/main/CONTRIBUTING.md
  One of the project maintainers will review your PR.
-->

# :eyes: Pull Request

**What type of PR is this**

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Pipeline
- [ ] Documentation

**Which issue(s) does this PR address?**

N/A

**What does this PR do? Why do we need it?**

While doing some testing, we found that any API events that were queued at app start would never be dispatched if the user never visited another page.  This PR updates the dequeuing logic so that those events are dispatched once an application config has been set.

**Does this PR include breaking changes? Does it contain changes that are not backwards compatible?**

- [ ] Yes
- [x] No

<!-- List any changes made in this PR that aren't backwards-compatible. -->
