### PR TITLE
feature: radios use other attributes for id

### DIFF
--- a/docs/change-directive.md
+++ b/docs/change-directive.md
@@ -144,6 +144,7 @@ For this select example the following data is captured with the `AnalyticEvent`.
 
 | AnalyticEvent property | Value                         |
 | ---------------------- | ----------------------------- |
+| `id`                   | "favoriteFood"                |
 | `label`                | "What is your favorite food?" |
 | `value`                | "ramen"                       |
 | `displayValue`         | "Ramen"                       |
@@ -166,11 +167,14 @@ For this select example the following data is captured with the `AnalyticEvent`.
 
 For this radio input example the following data is captured. The `label` property is a repeat of the `displayValue` rather than the question being asked in the paragraph element. While the user may see the elements as related, there is nothing technically that links the paragraph element to the following input elements.
 
-| AnalyticEvent property | Value   |
-| ---------------------- | ------- |
-| `label`                | "Ramen" |
-| `value`                | "ramen" |
-| `displayValue`         | "Ramen" |
+Another difference with radio inputs is that they will prioritize the `formControlName` or `name` attributes on the host element when setting the `id` of the `AnalyticEvent`. This helps with the many radio inputs representing a single question situation that is common with this type of control.
+
+| AnalyticEvent property | Value          |
+| ---------------------- | -------------- |
+| `id`                   | "favoriteFood" |
+| `label`                | "Ramen"        |
+| `value`                | "ramen"        |
+| `displayValue`         | "Ramen"        |
 
 To capture the question for the radio input example, it is recommended to prepare an `AnalyticEvent` object and set the `label` property to match what the user would see.
 

--- a/projects/oculr-ngx/src/lib/directives/change.directive.spec.ts
+++ b/projects/oculr-ngx/src/lib/directives/change.directive.spec.ts
@@ -15,6 +15,7 @@ import { AnalyticEvent } from 'oculr-ngx';
 import { EventDispatchService } from '../services/event-dispatch.service';
 import { ChangeDirective } from './change.directive';
 import { DirectiveService } from '../services/directive.service';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 describe('ChangeDirective', () => {
   let fixture: ComponentFixture<TestComponent>;
@@ -27,6 +28,7 @@ describe('ChangeDirective', () => {
     console.warn = jasmine.createSpy('warn');
 
     TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
       declarations: [TestComponent, NotSupportedComponent, ChangeDirective],
       providers: [{ provide: EventDispatchService, useValue: mockEventDispatchService }, DirectiveService],
     });
@@ -246,6 +248,32 @@ describe('ChangeDirective', () => {
       expect(mockEventDispatchService.trackChange).toHaveBeenCalledTimes(1);
       expect(mockEventDispatchService.trackChange).toHaveBeenCalledWith(expectedEvent);
     }));
+
+    it('uses the reactive form attribute formControlName for id', fakeAsync(() => {
+      expectedEvent.id = 'favoriteSeason';
+      expectedEvent.label = 'Summer';
+      expectedEvent.value = 'summer';
+      expectedEvent.displayValue = 'Summer';
+      const input = fixture.nativeElement.querySelector('#summer');
+      input.dispatchEvent(new Event('mousedown'));
+      input.click();
+      tick();
+      expect(mockEventDispatchService.trackChange).toHaveBeenCalledTimes(1);
+      expect(mockEventDispatchService.trackChange).toHaveBeenCalledWith(expectedEvent);
+    }));
+
+    it('uses the attribute name for id', fakeAsync(() => {
+      expectedEvent.id = 'favoriteCookie';
+      expectedEvent.label = 'Chocolate chip';
+      expectedEvent.value = 'chocolateChip';
+      expectedEvent.displayValue = 'Chocolate chip';
+      const input = fixture.nativeElement.querySelector('#chocolateChip');
+      input.dispatchEvent(new Event('mousedown'));
+      input.click();
+      tick();
+      expect(mockEventDispatchService.trackChange).toHaveBeenCalledTimes(1);
+      expect(mockEventDispatchService.trackChange).toHaveBeenCalledWith(expectedEvent);
+    }));
   });
 
   describe('select', () => {
@@ -307,7 +335,9 @@ describe('ChangeDirective', () => {
     it('does not dispatch a change event when an identifier is missing', fakeAsync(() => {
       const input = fixture.nativeElement.querySelector('.unicorn-background');
       input.dispatchEvent(new Event('mousedown'));
-      input.click();
+      input.dispatchEvent(new Event('keydown'));
+      input.value = 'Spot';
+      input.dispatchEvent(new Event('change'));
       tick();
       expect(mockEventDispatchService.trackChange).toHaveBeenCalledTimes(0);
       expect(console.warn).toHaveBeenCalled();
@@ -358,12 +388,20 @@ describe('ChangeDirective', () => {
     <label for="petName">Your pet's name:</label>
     <input oculrChange type="text" id="petName" />
 
+    <label for="unicornName">Your unicorn's name:</label>
+    <input oculrChange class="unicorn-background" type="text" />
+
     <!-- radio -->
     <input oculrChange type="radio" id="dragon" value="dragon" />
     <label for="dragon">Dragon</label>
 
-    <input oculrChange class="unicorn-background" type="radio" value="unicorn" />
-    <label>Unicorn</label>
+    <form [formGroup]="seasonsForm">
+      <input oculrChange type="radio" id="summer" value="summer" formControlName="favoriteSeason" />
+      <label for="summer">Summer</label>
+    </form>
+
+    <input oculrChange type="radio" id="chocolateChip" value="chocolateChip" name="favoriteCookie" />
+    <label for="chocolateChip">Chocolate chip</label>
 
     <!-- select -->
     <label for="favoriteFood">What is your favorite food?</label>
@@ -378,7 +416,11 @@ describe('ChangeDirective', () => {
     <textarea oculrChange id="story"></textarea>
   `,
 })
-class TestComponent {}
+class TestComponent {
+  seasonsForm = new FormGroup({
+    favoriteSeason: new FormControl(''),
+  });
+}
 
 @Component({
   template: `

--- a/projects/oculr-ngx/src/lib/services/directive.service.ts
+++ b/projects/oculr-ngx/src/lib/services/directive.service.ts
@@ -44,7 +44,15 @@ export class DirectiveService {
   }
 
   setId(analyticEvent: AnalyticEvent, elementRef: ElementRef<HTMLElement>): void {
-    const elementId = elementRef.nativeElement.getAttribute('id');
+    let elementId = elementRef.nativeElement.getAttribute('id');
+    if (
+      this.getElementName(elementRef) === 'input' &&
+      this.getInputType(elementRef as ElementRef<HTMLInputElement>) === 'radio'
+    ) {
+      const elementName = elementRef.nativeElement.getAttribute('name');
+      const reactiveFormName = elementRef.nativeElement.getAttribute('formControlName');
+      elementId = reactiveFormName || elementName || elementId;
+    }
     if (elementId) {
       analyticEvent.id ||= elementId;
     }


### PR DESCRIPTION
<!--
  Thank you for sending a pull request!
  Please take a look at our contribution guide: https://github.com/Progressive/oculr-ngx/blob/main/CONTRIBUTING.md
  One of the project maintainers will review your PR.
-->

# :eyes: Pull Request

**What type of PR is this**

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Pipeline
- [ ] Documentation

**Which issue(s) does this PR address?**
Fixes #50 
<!--List issue(s) below. Use "fixes #X" or "closes #X" and the issue will close automatically when the PR is merged.-->

**What does this PR do? Why do we need it?**
- Prioritizes `formControlName` and `name` attributes on radio inputs as these controls usually have a many inputs to one question relationship.

**Does this PR include breaking changes? Does it contain changes that are not backwards compatible?**

- [ ] Yes
- [x] No

<!-- List any changes made in this PR that aren't backwards-compatible. -->

**Additional information**

<!-- Include anything that would help your reviewer (e.g. screenshots). -->
