### PR TITLE
Allow client to turn off HTTP interception

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ Oculr has a set of directives that help capture various display or interaction e
 | [oculrChange](./change-directive.md) | A directive that captures input, select, and textarea changes. |
 | [oculrClick](./click-directive.md) | A directive that captures button and anchor clicks. |
 | [oculrDisplay](./display-directive.md) | A directive that captures when a host element is rendered. |
+| [oculrFocus](./focus-directive.md) | A directive that captures when a host element gains focus. |
+| [oculrTrackValidation](./track-validation-directive.md) | A directive that captures validation errors on a Reactive form control. |
 
 ## Page Views
 

--- a/docs/init-and-config.md
+++ b/docs/init-and-config.md
@@ -4,7 +4,6 @@
 
 After the library has been installed, it can be loaded into your application by importing it into your root module (typically an `AppModule`).
 
-
 ```typescript
 import { OculrAngularModule } from 'oculr-ngx';
 
@@ -44,25 +43,26 @@ function initializeAppFactory(oculrConfigService: ConfigurationService): () => O
 
 ### AppConfiguration
 
-| Property | Description |
-| -------- | ----------- |
-| `destinations` | An array containing one to many `DestinationConfig` [objects](#destinationconfig). Each destination option is a pre-defined service that is responsible for forwarding on emitted events to another location. |
+| Property         | Description                                                                                                                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `logHttpTraffic` | `true` if you want to log HTTP calls from your app; `false` otherwise.                                                                                                                                        |
+| `destinations`   | An array containing one to many `DestinationConfig` [objects](#destinationconfig). Each destination option is a pre-defined service that is responsible for forwarding on emitted events to another location. |
 
 ### DestinationConfig
 
-| Property | Description |
-| -------- | ----------- |
-| `name`| Any available option defined by the `Destinations` [enum](../projects/oculr-ngx/src/lib/models/destinations.enum.ts). A basic description for each is listed [below](#available-destinations). |
+| Property           | Description                                                                                                                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`             | Any available option defined by the `Destinations` [enum](../projects/oculr-ngx/src/lib/models/destinations.enum.ts). A basic description for each is listed [below](#available-destinations).        |
 | `sendCustomEvents` | A `boolean` value denoting whether you'd like your own custom event structure dispatched. [More information](#using-your-own-custom-event-object) can be found below on how this can be accomplished. |
-| `endpoint` | The URL to send events to |
-| `method` | The HTTP method (`POST` or `PUT`) to be used when calling `endpoint`. |
-| `headers` | An `HttpHeaders` [object](https://angular.io/api/common/http/HttpHeaders) containing any required headers for calling `endpoint`. |
+| `endpoint`         | The URL to send events to                                                                                                                                                                             |
+| `method`           | The HTTP method (`POST` or `PUT`) to be used when calling `endpoint`.                                                                                                                                 |
+| `headers`          | An `HttpHeaders` [object](https://angular.io/api/common/http/HttpHeaders) containing any required headers for calling `endpoint`.                                                                     |
 
 ### Available destinations
 
-| Name | Description | Required properties |
-| ---- | ----------- | ------------------- |
-| Console | Equivalent to sending every event to `console.log`. | `name` |
+| Name    | Description                                            | Required properties          |
+| ------- | ------------------------------------------------------ | ---------------------------- |
+| Console | Equivalent to sending every event to `console.log`.    | `name`                       |
 | HttpApi | Used for sending events to a single HTTP API endpoint. | `name`, `endpoint`, `method` |
 
 ## Using your own custom event object

--- a/projects/oculr-ngx/src/lib/interceptors/analytics.interceptor.spec.ts
+++ b/projects/oculr-ngx/src/lib/interceptors/analytics.interceptor.spec.ts
@@ -44,7 +44,7 @@ describe('Analytics Interceptor', () => {
       appConfig$: configSubject,
     };
     analyticsInterceptor = new AnalyticsInterceptor(mockEventDispatchService, mockTimeService, mockConfigService);
-    configSubject.next({});
+    configSubject.next({ logHttpTraffic: true });
   });
 
   describe('after construction', () => {
@@ -54,6 +54,7 @@ describe('Analytics Interceptor', () => {
       });
 
       configSubject.next({
+        logHttpTraffic: true,
         destinations: [{ name: Destinations.HttpApi, sendCustomEvents: false, endpoint: destinationUrl }],
       });
       flush();
@@ -65,6 +66,19 @@ describe('Analytics Interceptor', () => {
   });
 
   describe('intercept', () => {
+    describe('when HTTP logging is off', () => {
+      it('should just forward the request on', fakeAsync(() => {
+        configSubject.next({
+          logHttpTraffic: false,
+          destinations: [{ name: Destinations.HttpApi, sendCustomEvents: false, endpoint: destinationUrl }],
+        });
+        analyticsInterceptor.intercept(mockRequest, mockHttpHandler).subscribe(() => {
+          expect(mockHttpHandler.handle).toHaveBeenCalledOnceWith(mockRequest);
+        });
+        flush();
+      }));
+    });
+
     describe('when no destinations are defined', () => {
       it('queues the request to be dispatched later', fakeAsync(() => {
         analyticsInterceptor.intercept(mockRequest, mockHttpHandler).subscribe(() => {
@@ -84,6 +98,7 @@ describe('Analytics Interceptor', () => {
     describe('when a destination is defined', () => {
       beforeEach(() => {
         configSubject.next({
+          logHttpTraffic: true,
           destinations: [{ name: Destinations.HttpApi, sendCustomEvents: false, endpoint: destinationUrl }],
         });
       });

--- a/projects/oculr-ngx/src/lib/models/app-configuration.interface.ts
+++ b/projects/oculr-ngx/src/lib/models/app-configuration.interface.ts
@@ -9,5 +9,6 @@
 import { DestinationConfig } from './destination-config.interface';
 
 export interface AppConfiguration {
+  logHttpTraffic: boolean;
   destinations?: DestinationConfig[];
 }

--- a/projects/oculr-ngx/src/lib/services/configuration.service.spec.ts
+++ b/projects/oculr-ngx/src/lib/services/configuration.service.spec.ts
@@ -15,6 +15,7 @@ describe('ConfigurationService', () => {
 
   it('should allow an app config to be loaded on demand', () => {
     const expectedConfig: AppConfiguration = {
+      logHttpTraffic: false,
       destinations: [{ name: Destinations.Console, sendCustomEvents: false }],
     };
     service.loadAppConfig(expectedConfig);

--- a/projects/oculr-ngx/src/lib/services/configuration.service.ts
+++ b/projects/oculr-ngx/src/lib/services/configuration.service.ts
@@ -16,7 +16,7 @@ export class ConfigurationService {
   appConfig$: Observable<AppConfiguration>;
 
   constructor() {
-    this._appConfig$ = new BehaviorSubject({});
+    this._appConfig$ = new BehaviorSubject<AppConfiguration>({ logHttpTraffic: false });
     this.appConfig$ = this._appConfig$.asObservable();
   }
 


### PR DESCRIPTION
<!--
  Thank you for sending a pull request!
  Please take a look at our contribution guide: https://github.com/Progressive/oculr-ngx/blob/main/CONTRIBUTING.md
  One of the project maintainers will review your PR.
-->

# :eyes: Pull Request

**What type of PR is this**

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Pipeline
- [ ] Documentation

**Which issue(s) does this PR address?**

Closes #62 

**What does this PR do? Why do we need it?**

This PR adds a new configuration option - `logHttpTraffic` - that allows a client to turn off HTTP interception.

**Does this PR include breaking changes? Does it contain changes that are not backwards compatible?**

- [x] Yes
- [ ] No

Any existing clients - only `oso-web` at this point - need to be updated so they provide a value for `logHttpTraffic` in their `oculr` config.
