### PR TITLE
Add HttpClientModule to imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ export class AppModule {}
 
 function initializeAppFactory(oculrConfigService: ConfigurationService): () => Observable<boolean> {
   oculrConfigService.loadAppConfig({
+    logHttpTraffic: true,
     destinations: [
       {
         name: Destinations.Console,

--- a/projects/oculr-ngx/src/lib/oculr-ngx.module.ts
+++ b/projects/oculr-ngx/src/lib/oculr-ngx.module.ts
@@ -7,7 +7,7 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
 import { ConsoleService } from './destinations/console/console.service';
 import { HttpApiService } from './destinations/http-api/http-api.service';
@@ -27,7 +27,7 @@ import { LocationService } from './services/location.service';
 import { TimeService } from './services/time.service';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, HttpClientModule],
   declarations: [DisplayDirective, ClickDirective, ChangeDirective, FocusDirective, TrackValidationDirective],
   exports: [DisplayDirective, ClickDirective, ChangeDirective, FocusDirective, TrackValidationDirective],
   providers: [],


### PR DESCRIPTION
<!--
  Thank you for sending a pull request!
  Please take a look at our contribution guide: https://github.com/Progressive/oculr-ngx/blob/main/CONTRIBUTING.md
  One of the project maintainers will review your PR.
-->

# :eyes: Pull Request

**What type of PR is this**

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Pipeline
- [ ] Documentation

**Which issue(s) does this PR address?**

Closes #76 

**What does this PR do? Why do we need it?**

This PR adds the `HttpClientModule` as an import to the library.  In the small number of cases where the module is not already imported by the client, the library was crashing on app load.  This removes the dependency with the client.

**Does this PR include breaking changes? Does it contain changes that are not backwards compatible?**

- [ ] Yes
- [x] No

<!-- List any changes made in this PR that aren't backwards-compatible. -->
